### PR TITLE
introduce modules of go-1.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.10
+      - image: circleci/golang:1.11.0
     working_directory: /go/src/github.com/sammy00/workerpool
     steps:
       - checkout 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/sammy00/workerpool


### PR DESCRIPTION
employ the modules management for version control since go-1.11 to avoid future dependency on other dependency management tool